### PR TITLE
New syntax

### DIFF
--- a/addons/sourcemod/scripting/include/lastrequest.inc
+++ b/addons/sourcemod/scripting/include/lastrequest.inc
@@ -103,8 +103,8 @@ public void __pl_lastrequest_SetNTVOptional()
 	MarkNativeAsOptional("CleanupLR");
 }
 
-functag FuncLastRequest public(type, prisoner, guard);
-functag FuncProcessLR public(Handle:array, iLRNumber);
+typedef FuncLastRequest = function void(int type, int prisoner, int guard);
+typedef FuncProcessLR = function void(Handle array, int iLRNumber);
 
 
 forward void OnStartLR(int PrisonerIndex, int GuardIndex, int LR_Type);


### PR DESCRIPTION
fixes "fatal error 196: deprecated syntax; see https://wiki.alliedmods.net/SourcePawn_Transitional_Syntax#Typedefs"